### PR TITLE
added internet permissions

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
          In most cases you can leave this as-is, but you if you want to provide
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <application
         android:name="io.flutter.app.FlutterApplication"
         android:label="RemoteManagementApp"


### PR DESCRIPTION
In debug mode service extension and multiple permissions are enabled by default(in flutter)

However, in release mode you have to add internet permission in androidmanifest.xml manually.( Just like you add it in native development)